### PR TITLE
Add prompt preview feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ C:\Users\lucia\AppData\Roaming\FlowLauncher\Plugins\PromptVault\
 - **Search specific prompts**: `ptp email`, `ptp code`, `ptp meeting`
 - **Multi-word search**: `ptp code review`, `ptp email template`
 - **Select and use**: Press Enter to copy prompt to clipboard and auto-paste
+- **Preview prompt**: Open the context menu on a result and choose *Preview Prompt*
 
 ### 3. Testing
 
@@ -77,6 +78,7 @@ C:\Users\lucia\AppData\Roaming\FlowLauncher\Plugins\PromptVault\
 - Template variables (e.g., `{{message}}`) replaced with `[variable]` for readability
 - Truncated previews for optimal display
 - Tag integration in subtitles
+- Context menu preview to view full prompt
 
 #### Reliable Auto-Paste
 - Multiple fallback methods:

--- a/main.py
+++ b/main.py
@@ -88,6 +88,15 @@ class PromptVaultPlugin:
             cleaned = cleaned[:77] + "..."
         
         return cleaned if cleaned else "Template prompt"
+
+    def _clean_full_text(self, text):
+        """Clean prompt text for full preview without truncation"""
+        if not text:
+            return "No description available"
+
+        cleaned = re.sub(r'\{\{[^}]+\}\}', '[variable]', text)
+        cleaned = re.sub(r'\s+', ' ', cleaned).strip()
+        return cleaned if cleaned else "Template prompt"
     
     def _search_prompts(self, query_terms):
         """Search prompts across all fields with relevance ranking"""
@@ -283,7 +292,7 @@ class PromptVaultPlugin:
                     "prompt": prompt_text,
                     "title": title
                 })
-                
+
                 formatted_results.append({
                     "Title": title,
                     "SubTitle": subtitle,
@@ -291,7 +300,8 @@ class PromptVaultPlugin:
                     "JsonRPCAction": {
                         "method": "copy_prompt",
                         "parameters": [context_data]
-                    }
+                    },
+                    "ContextData": context_data
                 })
             
             return formatted_results
@@ -319,16 +329,55 @@ class PromptVaultPlugin:
                 self._auto_paste()
             
             return []
-            
+
         except Exception:
             return []
 
+    def preview_prompt(self, context_data):
+        """Return a preview result for the given prompt"""
+        try:
+            data = json.loads(context_data)
+            prompt_text = data.get('prompt', '')
+            title = data.get('title', 'Prompt Preview')
 
-def handle_jsonrpc_request(request_data):
+            preview = self._clean_full_text(prompt_text)
+
+            return [{
+                "Title": title,
+                "SubTitle": preview,
+                "IcoPath": "Images\\app.png",
+            }]
+        except Exception:
+            return []
+
+    def context_menu(self, context_data):
+        """Return context menu options for a result"""
+        return [
+            {
+                "Title": "Copy Prompt",
+                "IcoPath": "Images\\app.png",
+                "JsonRPCAction": {
+                    "method": "copy_prompt",
+                    "parameters": [context_data]
+                }
+            },
+            {
+                "Title": "Preview Prompt",
+                "IcoPath": "Images\\app.png",
+                "JsonRPCAction": {
+                    "method": "preview_prompt",
+                    "parameters": [context_data],
+                    "dontHideAfterAction": True
+                }
+            }
+        ]
+
+
+def handle_jsonrpc_request(request_data, prompts_file_path=None):
     """Handle JSON-RPC request from Flow Launcher"""
     try:
         # Initialize plugin
-        plugin = PromptVaultPlugin()
+        plugin = PromptVaultPlugin(prompts_file_path)
         
         if not request_data:
             return {"result": []}
@@ -346,13 +395,29 @@ def handle_jsonrpc_request(request_data):
         if method == 'query':
             query_text = parameters[0] if parameters else ""
             results = plugin.query(query_text)
+            if not isinstance(results, list):
+                return {"result": [{
+                    "Title": "Invalid Response Format",
+                    "SubTitle": "Query returned invalid format",
+                    "IcoPath": "Images\\app.png"
+                }]}
             return {"result": results}
-            
+
         elif method == 'copy_prompt':
             context_data = parameters[0] if parameters else ""
             results = plugin.copy_prompt(context_data)
             return {"result": results}
-        
+
+        elif method == 'preview_prompt':
+            context_data = parameters[0] if parameters else ""
+            results = plugin.preview_prompt(context_data)
+            return {"result": results}
+
+        elif method == 'context_menu':
+            context_data = parameters[0] if parameters else ""
+            results = plugin.context_menu(context_data)
+            return {"result": results}
+
         else:
             return {"result": []}
             
@@ -373,12 +438,16 @@ def main():
         input_data = ""
         if len(sys.argv) > 1:
             input_data = sys.argv[1]
-        
+
         if not input_data:
-            # No input, return empty result
+            try:
+                input_data = sys.stdin.read().strip()
+            except Exception:
+                input_data = ""
+
+        if not input_data:
             response = {"result": []}
         else:
-            # Handle the request
             response = handle_jsonrpc_request(input_data)
         
         # Output JSON response

--- a/test_prompt_vault.py
+++ b/test_prompt_vault.py
@@ -260,6 +260,31 @@ class PromptVaultTester:
             return True
         except Exception:
             return False
+
+    def test_preview_functionality(self):
+        """Test preview_prompt returns a valid result"""
+        try:
+            plugin = PromptVaultPlugin()
+            plugin.prompts_file_path = self.test_prompts_file
+            plugin._load_prompts()
+
+            first = plugin.prompts_data[0]
+            context_data = json.dumps({
+                "prompt": first["prompt"],
+                "title": first["title"]
+            })
+
+            results = plugin.preview_prompt(context_data)
+            if not isinstance(results, list) or len(results) != 1:
+                return False
+            result = results[0]
+            if result.get("Title") != first["title"]:
+                return False
+            if "SubTitle" not in result:
+                return False
+            return True
+        except Exception:
+            return False
     
     def test_clipboard_operations(self):
         """Test clipboard copy functionality"""
@@ -517,6 +542,7 @@ class PromptVaultTester:
             ("Search Functionality", self.test_search_functionality),
             ("JSON-RPC Query Request", self.test_jsonrpc_query_request),
             ("JSON-RPC Copy Action", self.test_jsonrpc_copy_action),
+            ("Preview Functionality", self.test_preview_functionality),
             ("Clipboard Operations", self.test_clipboard_operations),
             ("Error Handling", self.test_error_handling),
             ("JSON Output Format", self.test_json_output_format),


### PR DESCRIPTION
## Summary
- add context menu preview option to see the full prompt
- support preview_prompt and context_menu JSON-RPC actions
- return a helpful error when query results are invalid
- allow stdin as a fallback input method
- document preview usage
- extend tests with preview coverage

## Testing
- `python test_prompt_vault.py`

------
https://chatgpt.com/codex/tasks/task_e_68402300d7f0832ba62010a2ebc93cd2